### PR TITLE
Make PortMappingListener more useful to applications

### DIFF
--- a/UPnPIGD-Core/src/main/java/com/distrimind/upnp_igd/support/igd/PortMappingListener.java
+++ b/UPnPIGD-Core/src/main/java/com/distrimind/upnp_igd/support/igd/PortMappingListener.java
@@ -65,16 +65,19 @@ import java.util.logging.Logger;
  * }</pre>
  *
  * @author Christian Bauer
- * @author Richard Maw - Nullable internalClient, callbacks
+ * @author Richard Maw - Nullable internalClient, callbacks, InternetGatewayDevice:2
  */
 public class PortMappingListener extends DefaultRegistryListener {
 
     private static final Logger log = Logger.getLogger(PortMappingListener.class.getName());
 
-    public static final DeviceType IGD_DEVICE_TYPE = new UDADeviceType("InternetGatewayDevice", 1);
-    public static final DeviceType CONNECTION_DEVICE_TYPE = new UDADeviceType("WANConnectionDevice", 1);
+    public static final DeviceType IGD_DEVICE_TYPE_V1 = new UDADeviceType("InternetGatewayDevice", 1);
+    public static final DeviceType IGD_DEVICE_TYPE_V2 = new UDADeviceType("InternetGatewayDevice", 2);
+    public static final DeviceType CONNECTION_DEVICE_TYPE_V1 = new UDADeviceType("WANConnectionDevice", 1);
+    public static final DeviceType CONNECTION_DEVICE_TYPE_V2 = new UDADeviceType("WANConnectionDevice", 2);
 
-    public static final ServiceType IP_SERVICE_TYPE = new UDAServiceType("WANIPConnection", 1);
+    public static final ServiceType IP_SERVICE_TYPE_V1 = new UDAServiceType("WANIPConnection", 1);
+    public static final ServiceType IP_SERVICE_TYPE_V2 = new UDAServiceType("WANIPConnection", 2);
     public static final ServiceType PPP_SERVICE_TYPE = new UDAServiceType("WANPPPConnection", 1);
 
     protected List<PortMapping> portMappings;
@@ -189,16 +192,23 @@ public class PortMappingListener extends DefaultRegistryListener {
     }
 
     protected Service<?, ?, ?> discoverConnectionService(Device<?, ?, ?> device) {
-        if (!device.getType().equals(IGD_DEVICE_TYPE)) {
+        DeviceType deviceType = device.getType();
+        if (!deviceType.equals(IGD_DEVICE_TYPE_V1) && !deviceType.equals(IGD_DEVICE_TYPE_V2)) {
             return null;
         }
 
-        Collection<? extends Device<?, ?, ?>> connectionDevices = device.findDevices(CONNECTION_DEVICE_TYPE);
+        Collection<? extends Device<?, ?, ?>> connectionDevices = device.findDevices(CONNECTION_DEVICE_TYPE_V2);
         if (connectionDevices.isEmpty()) {
-			if (log.isLoggable(Level.FINE)) {
-				log.fine("IGD doesn't support '" + CONNECTION_DEVICE_TYPE + "': " + device);
-			}
-			return null;
+            if (log.isLoggable(Level.FINE)) {
+                log.fine("IGD doesn't support '" + CONNECTION_DEVICE_TYPE_V2 + "': " + device);
+            }
+            connectionDevices = device.findDevices(CONNECTION_DEVICE_TYPE_V1);
+        }
+        if (connectionDevices.isEmpty()) {
+            if (log.isLoggable(Level.FINE)) {
+                log.fine("IGD doesn't support '" + CONNECTION_DEVICE_TYPE_V1 + "': " + device);
+            }
+            return null;
         }
 
         Device<?, ?, ?> connectionDevice = connectionDevices.iterator().next();
@@ -206,16 +216,21 @@ public class PortMappingListener extends DefaultRegistryListener {
 			log.fine("Using first discovered WAN connection device: " + connectionDevice);
 		}
 
-		Service<?, ?, ?> ipConnectionService = connectionDevice.findService(IP_SERVICE_TYPE);
-        Service<?, ?, ?> pppConnectionService = connectionDevice.findService(PPP_SERVICE_TYPE);
+        Service<?, ?, ?> connectionService = connectionDevice.findService(IP_SERVICE_TYPE_V2);
+        if (connectionService == null) {
+            connectionService = connectionDevice.findService(IP_SERVICE_TYPE_V1);
+        }
+        if (connectionService == null) {
+            connectionService = connectionDevice.findService(PPP_SERVICE_TYPE);
+        }
 
-        if (ipConnectionService == null && pppConnectionService == null) {
+        if (connectionService == null) {
 			if (log.isLoggable(Level.FINE)) {
 				log.fine("IGD doesn't support IP or PPP WAN connection service: " + device);
 			}
 		}
 
-        return ipConnectionService != null ? ipConnectionService : pppConnectionService;
+        return connectionService;
     }
 
     protected void handleFailureMessage(String s) {


### PR DESCRIPTION
I am attempting to update an application's UPnP stack to something more recent.

PortMappingListener required a few extensions:

1. Specifying the address in advance isn't sufficient because the application doesn't configure the address, it attempts to use an appropriate address, so the most fitting approach is to pick an address after the IGDs have been discovered. By allowing the internal client to be nullable and if it is to use the address the device was discovered from, we can defer which address to use until after IGDs have been discovered.
2. Letting it run autonomously and map things doesn't give sufficient feedback for the application, which is used to waiting to see if any IGDs were discovered, and if they aren't within a reasonable time frame report an error message. Similarly it needs to know if any ports were successfully mapped or unmapped on shutdown. Adding some callbacks that can be overridden was sufficient for this.
3. My Router doesn't implement InternetGatewayDevice:1, but the methods are the same in InternetGatewayDevice:2 so it just needs to search for some backup device names.

After initially doing these modifications to jupnp and finding the license a problem for integration I have brought them here.